### PR TITLE
Added C Wrapper for missing approxPolyN

### DIFF
--- a/dartcv/imgproc/imgproc.cpp
+++ b/dartcv/imgproc/imgproc.cpp
@@ -30,6 +30,17 @@ CvStatus* cv_approxPolyDP(
     END_WRAP
 }
 
+CvStatus* cv_approxPolyN(
+    VecPoint curve, int nsides, float epsilon_percentage, bool ensure_convex, VecPoint* rval, CvCallback_0 callback
+) {
+    BEGIN_WRAP
+    cv::approxPolyN(CVDEREF(curve), CVDEREF_P(rval), nsides, epsilon_percentage, ensure_convex);
+    if (callback != nullptr) {
+        callback();
+    }
+    END_WRAP
+}
+
 CvStatus* cv_cvtColor(Mat src, Mat dst, int code, CvCallback_0 callback) {
     BEGIN_WRAP
     cv::cvtColor(CVDEREF(src), CVDEREF(dst), code);

--- a/dartcv/imgproc/imgproc.h
+++ b/dartcv/imgproc/imgproc.h
@@ -711,6 +711,9 @@ CvStatus* cv_approxPolyDP(
 
 // Approximates a polygon with a convex hull with a specified accuracy and number of sides.
 // void cv::approxPolyN (InputArray curve, OutputArray approxCurve, int nsides, float epsilon_percentage=-1.0, bool ensure_convex=true)
+CvStatus* cv_approxPolyN(
+    VecPoint curve, int nsides, float epsilon_percentage, bool ensure_convex, VecPoint* rval, CvCallback_0 callback
+);
 
 // Calculates a contour perimeter or a curve length.
 // double cv::arcLength (InputArray curve, bool closed)


### PR DESCRIPTION
Simply added the c wrapper for the missing `approxPolyN` function.